### PR TITLE
Use polyfill atomics instead of core atomics

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,11 +2,11 @@
 
 mod atomic_bitset;
 
+use atomic_polyfill::AtomicU32;
 use core::cell::UnsafeCell;
 use core::hash::{Hash, Hasher};
 use core::mem::MaybeUninit;
 use core::ops::{Deref, DerefMut};
-use core::sync::atomic::AtomicU32;
 use core::{cmp, mem, ptr::NonNull};
 
 use crate::atomic_bitset::AtomicBitset;


### PR DESCRIPTION
Ran into this trying to run embassy-net on an esp32c3 with esp-wifi :D.