### PR TITLE
Add support for initialising the pool to some value and allow allocating uninitialized boxes.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,15 +7,13 @@ repository = "https://github.com/embassy-rs/atomic-pool"
 edition = "2021"
 readme = "README.md"
 license = "MIT OR Apache-2.0"
-categories = [
-    "embedded",
-    "no-std",
-    "concurrency",
-    "memory-management",
-]
+categories = ["embedded", "no-std", "concurrency", "memory-management"]
 
 [dependencies]
 atomic-polyfill = "1.0"
 as-slice-01 = { package = "as-slice", version = "0.1.5" }
 as-slice-02 = { package = "as-slice", version = "0.2.1" }
 stable_deref_trait = { version = "1.2.0", default-features = false }
+
+[features]
+alloc_uninit = []

--- a/examples/initialised.rs
+++ b/examples/initialised.rs
@@ -1,0 +1,23 @@
+use atomic_pool::{pool, Box};
+use std::mem;
+
+pool!(TestPool: [u32; 3], [0u32; 3]);
+
+fn main() {
+    let mut buffer = unsafe { Box::<TestPool>::new_potentially_uninit() }.unwrap();
+    println!("Allocated new buffer, with contents: {:#x}", *buffer);
+
+    *buffer = 0xf00dbabeu32;
+
+    let _buffer_2 = unsafe { Box::<TestPool>::new_potentially_uninit() }.unwrap();
+    let _buffer_3 = unsafe { Box::<TestPool>::new_potentially_uninit() }.unwrap();
+
+    mem::drop(buffer);
+    println!("Dropped buffer.");
+
+    let reallocated_buffer = unsafe { Box::<TestPool>::new_potentially_uninit() }.unwrap();
+    println!(
+        "Reallocated buffer, with contents: 0x{:#x}",
+        *reallocated_buffer
+    );
+}

--- a/examples/initialised.rs
+++ b/examples/initialised.rs
@@ -4,18 +4,18 @@ use std::mem;
 pool!(TestPool: [u32; 3], [0u32; 3]);
 
 fn main() {
-    let mut buffer = unsafe { Box::<TestPool>::new_potentially_uninit() }.unwrap();
+    let mut buffer = unsafe { Box::<TestPool>::new_uninit() }.unwrap();
     println!("Allocated new buffer, with contents: {:#x}", *buffer);
 
     *buffer = 0xf00dbabeu32;
 
-    let _buffer_2 = unsafe { Box::<TestPool>::new_potentially_uninit() }.unwrap();
-    let _buffer_3 = unsafe { Box::<TestPool>::new_potentially_uninit() }.unwrap();
+    let _buffer_2 = unsafe { Box::<TestPool>::new_uninit() }.unwrap();
+    let _buffer_3 = unsafe { Box::<TestPool>::new_uninit() }.unwrap();
 
     mem::drop(buffer);
     println!("Dropped buffer.");
 
-    let reallocated_buffer = unsafe { Box::<TestPool>::new_potentially_uninit() }.unwrap();
+    let reallocated_buffer = unsafe { Box::<TestPool>::new_uninit() }.unwrap();
     println!(
         "Reallocated buffer, with contents: 0x{:#x}",
         *reallocated_buffer

--- a/examples/simple.rs
+++ b/examples/simple.rs
@@ -1,3 +1,4 @@
+#![allow(unused)]
 use std::mem;
 
 use atomic_pool::{pool, Box};

--- a/examples/uninit.rs
+++ b/examples/uninit.rs
@@ -1,9 +1,11 @@
-use atomic_pool::{pool, Box};
-use std::mem;
+use atomic_pool::pool;
 
 pool!(TestPool: [u32; 3]);
 
+#[cfg(feature = "alloc_uninit")]
 fn main() {
+    use atomic_pool::Box;
+    use std::mem;
     let mut buffer = unsafe { Box::<TestPool>::new_uninit() }.unwrap();
     println!("Allocated new buffer.");
 
@@ -21,3 +23,5 @@ fn main() {
         *reallocated_buffer
     );
 }
+#[cfg(not(feature = "alloc_uninit"))]
+fn main() {}

--- a/examples/uninit.rs
+++ b/examples/uninit.rs
@@ -1,11 +1,11 @@
 use atomic_pool::{pool, Box};
 use std::mem;
 
-pool!(TestPool: [u32; 3], [0u32; 3]);
+pool!(TestPool: [u32; 3]);
 
 fn main() {
     let mut buffer = unsafe { Box::<TestPool>::new_uninit() }.unwrap();
-    println!("Allocated new buffer, with contents: {:#x}", *buffer);
+    println!("Allocated new buffer.");
 
     *buffer = 0xf00dbabeu32;
 
@@ -17,7 +17,7 @@ fn main() {
 
     let reallocated_buffer = unsafe { Box::<TestPool>::new_uninit() }.unwrap();
     println!(
-        "Reallocated buffer, with contents: 0x{:#x}",
+        "Reallocated buffer, with contents: {:#x}",
         *reallocated_buffer
     );
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -105,8 +105,8 @@ impl<P: Pool> Box<P> {
     }
 
     /// Turn this box into a raw pointer.
-    /// 
-    /// Once you turn a box into a raw pointer, it becomes your responsibility to free it properly again. 
+    ///
+    /// Once you turn a box into a raw pointer, it becomes your responsibility to free it properly again.
     /// This can be done, by creating a box from that raw pointer again, using [Self::from_raw].
     pub fn into_raw(b: Self) -> NonNull<P::Item> {
         let res = b.ptr;
@@ -115,7 +115,7 @@ impl<P: Pool> Box<P> {
     }
 
     /// Create a box from a raw pointer.
-    /// 
+    ///
     /// # Safety
     /// You must ensure, that the pointer points to valid memory, which was allocated from the pool in the generic parameter.
     /// If you fail to do so, this will trigger a panic, once this box is dropped.
@@ -265,21 +265,6 @@ macro_rules! pool {
             type Storage = $crate::PoolStorageImpl<$ty, {$n}, {($n+31)/32}>;
             fn get() -> &'static Self::Storage {
                 static POOL: $crate::PoolStorageImpl<$ty, {$n}, {($n+31)/32}> = $crate::PoolStorageImpl::new();
-                &POOL
-            }
-        }
-    };
-    ($vis:vis $name:ident: [$ty:ty; $n:expr], $initial_value:expr) => {
-        $vis struct $name { _uninhabited: ::core::convert::Infallible }
-        impl $crate::Pool for $name {
-            type Item = $ty;
-            type Storage = $crate::PoolStorageImpl<$ty, {$n}, {($n+31)/32}>;
-            fn get() -> &'static Self::Storage {
-                static POOL: $crate::PoolStorageImpl<$ty, {$n}, {($n+31)/32}> = {
-                    let mut pool_storage_impl = $crate::PoolStorageImpl::new();
-                    pool_storage_impl.data = unsafe { ::core::mem::transmute($initial_value) };
-                    pool_storage_impl
-                };
                 &POOL
             }
         }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -90,6 +90,13 @@ impl<P: Pool> Box<P> {
         unsafe { p.as_ptr().write(item) };
         Some(Self { ptr: p })
     }
+    pub unsafe fn new_potentially_uninit() -> Option<Self> {
+        let p = match P::get().alloc() {
+            Some(p) => p,
+            None => return None,
+        };
+        Some(Self { ptr: p })
+    }
 
     pub fn into_raw(b: Self) -> NonNull<P::Item> {
         let res = b.ptr;


### PR DESCRIPTION
Hi,
this PR adds support for initializing the pool to some default value and allocating uninitialized boxes.
In my project, I want to use this for having a pool of fixed size buffers, for TX/RX of Wi-Fi frames, in my use case, it would incur a significant performance overhead, to clear the buffer.
I also expanded the docs a bit, to help people using this library for the first time.