### PR TITLE
Replace depreciated atomic-polyfill crate with portable-atomic

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 2.0.0 - 2025-01-02
+
+- Replace deprecated `atomic-polyfill` crate with `portable-atomic`.
+
 ## 1.0.1 - 2022-12-11
 
 - Use `atomic-polyfill`, to support targets without atomic CAS.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,21 +1,16 @@
 [package]
 name = "atomic-pool"
-version = "1.0.1"
+version = "2.0.0"
 authors = ["Dario Nieuwenhuis <dirbaio@dirbaio.net>"]
 description = "Statically allocated pool providing a std-like Box."
 repository = "https://github.com/embassy-rs/atomic-pool"
 edition = "2021"
 readme = "README.md"
 license = "MIT OR Apache-2.0"
-categories = [
-    "embedded",
-    "no-std",
-    "concurrency",
-    "memory-management",
-]
+categories = ["embedded", "no-std", "concurrency", "memory-management"]
 
 [dependencies]
-atomic-polyfill = "1.0"
 as-slice-01 = { package = "as-slice", version = "0.1.5" }
 as-slice-02 = { package = "as-slice", version = "0.2.1" }
+portable-atomic = { version = "1.7.0" }
 stable_deref_trait = { version = "1.2.0", default-features = false }

--- a/README.md
+++ b/README.md
@@ -4,6 +4,22 @@
 
 Statically allocated pool providing a std-like Box.
 
+## Support for targets without atomic CAS
+
+This crate uses [`portable-atomic`](https://crates.io/crates/portable-atomic) to polyfill atomic
+compare-and-swap operations on targets without native hardware support for it.
+
+To use it, you must add a dependency on `portable-atomic` and enable one of its features to
+specify how the polyfilling is done. The feature is typically `unsafe-assume-single-core` for
+single-core chips running in supervisor mode, or `critical-section` otherwise. Check `portable-atomic`'s
+README for more details.
+
+```toml
+[dependencies]
+atomic-pool = "2.0"
+portable-atomic = { version = "1", default-features = false, features = ["critical-section"] }
+```
+
 ## License
 
 This work is licensed under either of

--- a/ci.sh
+++ b/ci.sh
@@ -3,5 +3,5 @@
 set -euxo pipefail
 
 cargo test
-cargo build --target thumbv6m-none-eabi
+cargo build --target thumbv6m-none-eabi --features portable-atomic/unsafe-assume-single-core
 cargo build --target thumbv7em-none-eabi

--- a/src/atomic_bitset.rs
+++ b/src/atomic_bitset.rs
@@ -1,4 +1,4 @@
-use atomic_polyfill::{AtomicU32, Ordering};
+use portable_atomic::{AtomicU32, Ordering};
 
 pub struct AtomicBitset<const N: usize, const K: usize>
 where

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,12 +2,12 @@
 
 mod atomic_bitset;
 
-use atomic_polyfill::AtomicU32;
 use core::cell::UnsafeCell;
 use core::hash::{Hash, Hasher};
 use core::mem::MaybeUninit;
 use core::ops::{Deref, DerefMut};
 use core::{cmp, mem, ptr::NonNull};
+use portable_atomic::AtomicU32;
 
 use crate::atomic_bitset::AtomicBitset;
 


### PR DESCRIPTION
`atomic-polyfill` has been depreciated and is causing problems in my ESP32-S3 build system. `portable-atomic` is the widely-accepted replacement and I have updated the library to use it.