### PR TITLE
Fix nightly warning `manually reimplementing div_ceil.` in `pool!()` and other clippy suggestions.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased 
+
+- Clippy warning `manually reimplementing div_ceil` when using `pool!()` in nightly in your own application.
+- Fixed many clippy suggestions.
+
 ## 2.0.0 - 2025-01-02
 
 - Replace deprecated `atomic-polyfill` crate with `portable-atomic`.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "atomic-pool"
-version = "2.0.0"
+version = "2.0.1"
 authors = ["Dario Nieuwenhuis <dirbaio@dirbaio.net>"]
 description = "Statically allocated pool providing a std-like Box."
 repository = "https://github.com/embassy-rs/atomic-pool"
@@ -12,5 +12,5 @@ categories = ["embedded", "no-std", "concurrency", "memory-management"]
 [dependencies]
 as-slice-01 = { package = "as-slice", version = "0.1.5" }
 as-slice-02 = { package = "as-slice", version = "0.2.1" }
-portable-atomic = { version = "1.7.0" }
+portable-atomic = { version = "1.10.0" }
 stable_deref_trait = { version = "1.2.0", default-features = false }

--- a/examples/simple.rs
+++ b/examples/simple.rs
@@ -10,6 +10,7 @@ pool!(PacketPool: [Packet; 4]);
 fn main() {
     let box1 = Box::<PacketPool>::new(Packet(1));
     println!("allocated: {:?}", box1);
+    assert_eq!(box1.as_ref().map(|b| b.0), Some(1));
 
     let box2 = Box::<PacketPool>::new(Packet(2));
     println!("allocated: {:?}", box2);

--- a/src/atomic_bitset.rs
+++ b/src/atomic_bitset.rs
@@ -12,8 +12,9 @@ where
     [AtomicU32; K]: Sized,
 {
     pub const fn new() -> Self {
-        const Z: AtomicU32 = AtomicU32::new(0);
-        Self { used: [Z; K] }
+        Self {
+            used: [const { AtomicU32::new(0) }; K],
+        }
     }
 
     pub fn alloc(&self) -> Option<usize> {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -237,9 +237,9 @@ macro_rules! pool {
         $vis struct $name { _uninhabited: ::core::convert::Infallible }
         impl $crate::Pool for $name {
             type Item = $ty;
-            type Storage = $crate::PoolStorageImpl<$ty, {$n}, {($n+31)/32}>;
+            type Storage = $crate::PoolStorageImpl<$ty, {$n}, {usize::div_ceil($n,32)}>;
             fn get() -> &'static Self::Storage {
-                static POOL: $crate::PoolStorageImpl<$ty, {$n}, {($n+31)/32}> = $crate::PoolStorageImpl::new();
+                static POOL: $crate::PoolStorageImpl<$ty, {$n}, {usize::div_ceil($n,32)}> = $crate::PoolStorageImpl::new();
                 &POOL
             }
         }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -105,8 +105,12 @@ impl<P: Pool> Box<P> {
         res
     }
 
+    /// Constructs a box from a [`NonNull`] pointer.
+    ///
     /// # Safety
-    /// See [`NonNull`] for safety requirements.
+    /// This function is unsafe because improper use may lead to memory problems.
+    /// For example, a double-free may occur if the function is called twice on the same [`NonNull`] pointer.
+    /// See also [std::boxed::Box#method.from_non_null] for more information about safety and memorylayout.
     pub unsafe fn from_raw(ptr: NonNull<P::Item>) -> Self {
         Self { ptr }
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -11,6 +11,9 @@ use portable_atomic::AtomicU32;
 
 use crate::atomic_bitset::AtomicBitset;
 
+/// `AtomicU32` has the same number of bits as `u32`
+pub const ATOMICU32_BITS: usize = u32::BITS as usize;
+
 /// Implementation detail. Not covered by semver guarantees.
 #[doc(hidden)]
 pub trait PoolStorage<T> {
@@ -244,9 +247,9 @@ macro_rules! pool {
         $vis struct $name { _uninhabited: ::core::convert::Infallible }
         impl $crate::Pool for $name {
             type Item = $ty;
-            type Storage = $crate::PoolStorageImpl<$ty, {$n}, {usize::div_ceil($n,32)}>;
+            type Storage = $crate::PoolStorageImpl<$ty, {$n}, {usize::div_ceil($n,$crate::ATOMICU32_BITS)}>;
             fn get() -> &'static Self::Storage {
-                static POOL: $crate::PoolStorageImpl<$ty, {$n}, {usize::div_ceil($n,32)}> = $crate::PoolStorageImpl::new();
+                static POOL: $crate::PoolStorageImpl<$ty, {$n}, {usize::div_ceil($n,$crate::ATOMICU32_BITS)}> = $crate::PoolStorageImpl::new();
                 &POOL
             }
         }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -35,12 +35,10 @@ impl<T, const N: usize, const K: usize> PoolStorageImpl<T, N, K>
 where
     [AtomicU32; K]: Sized,
 {
-    const UNINIT: UnsafeCell<MaybeUninit<T>> = UnsafeCell::new(MaybeUninit::uninit());
-
     pub const fn new() -> Self {
         Self {
             used: AtomicBitset::new(),
-            data: [Self::UNINIT; N],
+            data: [const { UnsafeCell::new(MaybeUninit::uninit()) }; N],
         }
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -61,13 +61,13 @@ where
 {
     fn alloc(&self) -> Option<NonNull<T>> {
         let n = self.used.alloc()?;
-        let p = self.data[n].get() as *mut T;
+        let p = self.data[n].get().cast::<T>();
         Some(unsafe { NonNull::new_unchecked(p) })
     }
 
     /// safety: p must be a pointer obtained from self.alloc that hasn't been freed yet.
     unsafe fn free(&self, p: NonNull<T>) {
-        let origin = self.data.as_ptr() as *mut T;
+        let origin = self.data.as_ptr().cast::<T>();
         let n = p.as_ptr().offset_from(origin);
         assert!(n >= 0);
         assert!((n as usize) < N);
@@ -237,7 +237,7 @@ where
     where
         H: Hasher,
     {
-        <P::Item as Hash>::hash(self, state)
+        <P::Item as Hash>::hash(self, state);
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -110,7 +110,7 @@ impl<P: Pool> Box<P> {
     /// # Safety
     /// This function is unsafe because improper use may lead to memory problems.
     /// For example, a double-free may occur if the function is called twice on the same [`NonNull`] pointer.
-    /// See also [std::boxed::Box#method.from_non_null] for more information about safety and memorylayout.
+    /// See also [`std::boxed::Box#method.from_non_null`] for more information about safety and memorylayout.
     pub unsafe fn from_raw(ptr: NonNull<P::Item>) -> Self {
         Self { ptr }
     }


### PR DESCRIPTION
The main reason for this PR is 5224dda9833d6885b150632b8db07e1ca336f693
When using nightly and the macro `pool!()`, is shows a warning about `manually reimplementing div_ceil.`.
While I was busy I also fixes more warnings and clippy suggestions.
I bumped to v2.0.1 because no external interfaces are changed.
Maybe bump of `portable-atomic` can considert as a breaking change?