### PR TITLE
Record MSRV of 1.79.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,6 +8,7 @@ edition = "2021"
 readme = "README.md"
 license = "MIT OR Apache-2.0"
 categories = ["embedded", "no-std", "concurrency", "memory-management"]
+rust-version = "1.79.0"
 
 [dependencies]
 as-slice-01 = { package = "as-slice", version = "0.1.5" }


### PR DESCRIPTION
This project does not use `rust-version` in its `Cargo.toml` to record its MSRV. Using `cargo msrv`, I've determined this to be Rust 1.79.0. Here's a build failure on 1.78.0:

```
Check for toolchain '1.78.0-aarch64-apple-darwin' failed with:
┌──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┐
│ Checking atomic-pool v2.0.1 (/Users/levi.morrison/go/src/github.com/embassy-rs/atomic-pool)                          │
│ error[E0658]: inline-const is experimental                                                                           │
│   --> src/lib.rs:44:20                                                                                               │
│    |                                                                                                                 │
│ 44 |             data: [const { UnsafeCell::new(MaybeUninit::uninit()) }; N],                                        │
│    |                    ^^^^^                                                                                        │
│    |                                                                                                                 │
│    = note: see issue #76001 <https://github.com/rust-lang/rust/issues/76001> for more information                    │
│                                                                                                                      │
│ error[E0658]: inline-const is experimental                                                                           │
│   --> src/atomic_bitset.rs:18:20                                                                                     │
│    |                                                                                                                 │
│ 18 |             used: [const { AtomicU32::new(0) }; K],                                                             │
│    |                    ^^^^^                                                                                        │
│    |                                                                                                                 │
│    = note: see issue #76001 <https://github.com/rust-lang/rust/issues/76001> for more information                    │
│                                                                                                                      │
│ For more information about this error, try `rustc --explain E0658`.                                                  │
│ error: could not compile `atomic-pool` (lib) due to 2 previous errors                                                │
└──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┘
```

And indeed, `inline-const` was stabilized on Rust 1.79.